### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/arshpunia/f21dc564-bd60-49a7-b5c2-10769ec8a128/d1d1c924-8591-4a10-af2f-b6f3b9b6a6e4/_apis/work/boardbadge/412e224a-5339-40d6-b182-959afd328b8f)](https://dev.azure.com/arshpunia/f21dc564-bd60-49a7-b5c2-10769ec8a128/_boards/board/t/d1d1c924-8591-4a10-af2f-b6f3b9b6a6e4/Microsoft.RequirementCategory)
 # Azure DevOps Tutorial
 
 This repository acts as a placeholder for activities related to AZ-400 training.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.